### PR TITLE
Ensure safe permissions on gnupg home.

### DIFF
--- a/libraries/gpg.rb
+++ b/libraries/gpg.rb
@@ -15,7 +15,17 @@ def gpg_encrypt(data, recipients)
   # Chef always uses root's GPG keyring.
   GPGME::Engine.home_dir='/root/.gnupg'
 
-  crypto = GPGME::Crypto.new :armor => true
-  data = crypto.encrypt(data, :recipients => recipients)
-  data.read
+  if GPGME::Key.find(:public, recipients).empty?
+    raise RuntimeError.new("gpg_encrypt couldn't find public keys for recipients: " + recipients)
+  end
+
+  begin
+    crypto = GPGME::Crypto.new :armor => true
+    data = crypto.encrypt(data, :recipients => recipients)
+    data.read
+  rescue
+    Chef::Log.error "gpg_encrypt failed encrypting for recipients: " + recipients
+    raise
+  end
+
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,7 @@ gpg_home = File.join(user_home, node['gpg']['homedir'])
 
 directory gpg_home do
   owner node['gpg']['user']
+  mode 00700
   action :nothing
 end.run_action(:create)
 


### PR DESCRIPTION
GnuPG complains if its home directory is accessible by group or other.  This change ensures only the gpg user has access.
